### PR TITLE
[#07] Day06 - fetch

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NEXT_MOVIE_API_URL = "http://localhost:12345/movie"

--- a/README.md
+++ b/README.md
@@ -3,15 +3,17 @@
 > [한 입 크기로 잘라먹는 Next.js(15+)](https://www.inflearn.com/course/%ED%95%9C%EC%9E%85-%ED%81%AC%EA%B8%B0-nextjs)강의 학습 후 정리한 내용입니다.
 
 # 목차
-1. [NextJS](#nextJS)
+1. [What NextJS](#what-nextjs)
 2. [pre-rendering](#pre-rendering)
 3. [pre-fetching](#pre-fetching)
 4. [Router](#router)
 5. [API Router](#api-router)
 6. [global layout](#global-layout)
-6. [global layout by page](#global-layout-by-page)
+7. [global layout by page](#global-layout-by-page)
+8. [data fetching](#data-fetching)
+9. [pre-rendering-method-of-next](#pre-rendering-method-of-next)
 
-# NextJS
+# What NextJS
 
 리액트 전용 프레임워크로 리액트의 확장판이라고 생각한다. 리액트는 UI, 즉 View를 위한 라이브러리이다. 그래서 라우팅, 최적화 등 그 외적인 것은 개발자의 역량이다. 그래서 그것들은 좀 더 편리하게 해주기 위해 넥스트가 나왔다고 생각한다. 리액트의 고립된 CSR을 입맛에 맞게 SSR, SSG, 하이드레이션 등의 메커니즘을 도입하여 좀 더 리액트를 맛깔나게 사용할 수 있도록 한다고 생각된다.
 
@@ -229,3 +231,91 @@
   <hr/>
 </details>
 <br>
+
+# data fetching
+기존 리액트에서의 데이터 통신을 알아보면 [초반 pre-rendering](#pre-rendering)에서 이야기 했듯이 FCP이후 JS번들을 통해 TTI가 가능해져서 길어진 랜더링과 그 후에 통신을 하다보니 데이터를 받아오는 시점이 늦게된다. 넥스트의 경우 초반 사전 렌더링 된 화면을 받아 올 때 그 화면에 필요한 데이터까지도 미리 받아서 전달해주는 매커니즘을 가지고 있다. 그 또한 개발자가 설정해 줄 수 있다. 또한 오래걸리는 데이터 패칭도 빌드 타임에 미리 패칭하는 매커니즘도 제공하고 있다. 
+
+정리하면 리액트의 경우 화면 마운트 후 데이터 패칭을 한다면, 넥스트는 사전 렌더링할 때에 데이터 패칭도 발생하게 할 수 있어서 훨씬 빠르게 사용자가 데이터를 패칭할 수 있다.
+
+# pre-rendering method of next
+
+## 1. SSR
+> Server Side Rendering으로, 요청이 들어올 때 사전 렌더링을 진행한다. 
+<details>
+  <summary>Page Router</summary>
+  <hr/>
+  
+  ```jsx
+    export const getServerSideProps = () => {}
+  ```
+  위와 같이 파일 중 컴포넌트 외부에 `getServerSideProps`라는 이름으로 함수를 지정하고 내부에 로직을 적어주면 사전 렌더일 때 컴포넌트의 props로 자동으로 들어간다. 
+
+  ```jsx
+    export const getServerSideProps = () => {
+      const data = 통신으로 받아온 데이터()
+
+      return {
+        props: {
+          data
+        }
+      }
+    }
+  ```
+  `inferGetServerSidePropsType`이라고 자동으로 서버  사이드에서 props로 넘겨주는 데이터 타입을 추론하는 타입을 지원해줘서 편리하게 사용할 수 있다.
+
+  ```jsx
+    //...
+    export const getServerSideProps = () => {
+      const data = 통신으로 받아온 데이터()
+
+      return {
+        props: {
+          data
+        }
+      }
+    }
+
+    //...
+
+    export default Page({
+      data
+    }: inferGetServerSidePropsType<typeof getServerSideProps>)
+
+    //...
+  ```
+
+  `getServerSideProps`는 서버측에서 실행되는 함수이기 때문에 내부에 `console.log()`를 사용해도 클라이언트측인 브라우저에서는 출력되지 않고, 실행시킨 터미널에서 확인 할 수 있다.
+
+  컴포넌트는 총 2번 실행된다. 
+  1. 서버에서 사전 렌더링을 위해
+  2. JS번들을 통해 하이드레이션을 위해
+  그래서 컴포넌트 내부에 `console.log(window)`를 실행 시키면 위의 1번은 서버에서 실행이 될 때에는 `window`가 `undefined`이기 때문에 에러를 보내준다. 그래서 컴포넌트 내부에서 사용할 때에는 `useEffect`를 사용해줘야 한다.
+</details>
+<details>
+  <summary>App Router</summary>
+  <hr/>
+</details>
+
+
+## 2. SSG
+> Static Site Generation, 정적 사이트 생성으로, 빌드 타임에 사전 렌더링을 진행하여 좀 더 정적인 페이지를 접할 수 있다.
+<details>
+  <summary>Page Router</summary>
+  <hr/>
+</details>
+<details>
+  <summary>App Router</summary>
+  <hr/>
+</details>
+
+## 3. ISR
+> Incremental Static Regeneration, 점진적 정적 재생성으로, SSR의 장점과 SSG의 장점만을 살려 미리 렌더링 된 페이지를 보내고 시간이 지나면 새로운 요청을 갱신하는 매커니즘이다.
+
+<details>
+  <summary>Page Router</summary>
+  <hr/>
+</details>
+<details>
+  <summary>App Router</summary>
+  <hr/>
+</details>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,44 +1,38 @@
-import { ReactNode, useMemo } from "react";
+import { ReactNode } from "react";
+import { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 
-import type { MovieData } from "@/typesc";
-
-import dummyData from "@/mocks/dummy.json";
+import fetchMovie from "@/utils/fetch-movie";
+import fetchRecommendMovies from "@/utils/fetch-recommend-movie";
 
 import SearchableLayout from "@/components/searchable-layout";
 import MovieItem from "@/components/movie-item";
 
 import style from "./index.module.css";
 
-export default function Home() {
-  const getRecommendMovies = (movies: MovieData[], count: number = 3) => {
-    if (movies.length < count) {
-      throw new Error("배열의 길이가 선택하려는 갯수보다 적습니다.");
-    }
+export const getServerSideProps = async () => {
+  const [allMovies, recommendMovies] = await Promise.all([
+    fetchMovie(),
+    fetchRecommendMovies(),
+  ]);
 
-    if (movies.length === count) {
-      return movies;
-    }
-
-    const result = movies.slice();
-
-    for (let i = movies.length - 1; i > movies.length - 1 - count; i--) {
-      const randomIndex = Math.floor(Math.random() * (i + 1));
-
-      [result[i], result[randomIndex]] = [result[randomIndex], result[i]];
-    }
-
-    return result.slice(-count);
+  return {
+    props: {
+      allMovies,
+      recommendMovies,
+    },
   };
-
-  const recommendMovie = useMemo(() => getRecommendMovies(dummyData), []);
-
+};
+export default function Home({
+  allMovies,
+  recommendMovies,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <div className={style.container}>
       <section>
         <h3>지금 가장 추천하는 영화</h3>
         <div className={style.movie_items}>
-          {recommendMovie.map((movie) => {
+          {recommendMovies.map((movie) => {
             return (
               <Link
                 href={`/movie/${movie.id}`}
@@ -54,7 +48,7 @@ export default function Home() {
       <section>
         <h3>등록된 모든 영화</h3>
         <div className={style.movie_items}>
-          {dummyData.map((movie) => {
+          {allMovies.map((movie) => {
             return (
               <Link
                 href={`/movie/${movie.id}`}

--- a/src/pages/movie/[id].tsx
+++ b/src/pages/movie/[id].tsx
@@ -1,17 +1,31 @@
+import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 
-import type { MovieData } from "@/typesc";
-
-import dummyData from "@/mocks/dummy.json";
+import fetchOneMovie from "@/utils/fetch-one-movie";
 
 import style from "./[id].module.css";
 
-export default function Page() {
+export const getServerSideProps = async (
+  content: GetServerSidePropsContext
+) => {
+  const movieId = Number(content.params!.id);
+
+  const oneMovie = await fetchOneMovie(movieId);
+
+  return {
+    props: {
+      oneMovie,
+    },
+  };
+};
+
+export default function Page({
+  oneMovie,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const movieId = Number(router.query.id);
-  const movieDetail = dummyData.find(({ id }) => id === movieId) as MovieData;
 
-  if (!movieDetail) {
+  if (!oneMovie) {
     return (
       <div className={style.not_found}>
         &quot;ID: {movieId}&quot;에 해당하는 영화는 없습니다.
@@ -28,7 +42,7 @@ export default function Page() {
     genres,
     runtime,
     posterImgUrl,
-  } = movieDetail;
+  } = oneMovie;
 
   return (
     <div className={style.container}>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,23 +1,36 @@
 import { ReactNode } from "react";
+import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import Link from "next/link";
 
-import dummyData from "@/mocks/dummy.json";
+import fetchMovie from "@/utils/fetch-movie";
 
 import SearchableLayout from "@/components/searchable-layout";
 import MovieItem from "@/components/movie-item";
 
 import style from "./index.module.css";
 
-export default function Page() {
+export const getServerSideProps = async (
+  content: GetServerSidePropsContext
+) => {
+  const q = content.query.q;
+
+  const searchMovies = await fetchMovie(q as string);
+
+  return {
+    props: {
+      searchMovies,
+    },
+  };
+};
+
+export default function Page({
+  searchMovies,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const serachName = router.query.q as string;
 
-  const searchMovie = dummyData.filter(({ title }) =>
-    title.includes(serachName)
-  );
-
-  if (searchMovie.length === 0) {
+  if (searchMovies.length === 0) {
     return (
       <div className={style.not_found}>
         &quot;{serachName}&quot;에 대한 검색 결과가 없습니다.
@@ -26,7 +39,7 @@ export default function Page() {
   }
   return (
     <div className={style.movie_items}>
-      {searchMovie.map((movie) => {
+      {searchMovies.map((movie) => {
         return (
           <Link
             href={`/movie/${movie.id}`}

--- a/src/utils/fetch-movie.ts
+++ b/src/utils/fetch-movie.ts
@@ -1,10 +1,10 @@
 import { MovieData } from "@/typesc";
 
-export default async function fetchMovie(): Promise<MovieData[]> {
+export default async function fetchMovie(q?: string): Promise<MovieData[]> {
   const url = process.env.NEXT_MOVIE_API_URL as string;
 
   try {
-    const response = await fetch(url);
+    const response = await fetch(q ? `${url}/search?q=${q}` : url);
     if (!response.ok) {
       throw new Error("영화를 불러오는데 실패했습니다.");
     }

--- a/src/utils/fetch-movie.ts
+++ b/src/utils/fetch-movie.ts
@@ -1,0 +1,19 @@
+import { MovieData } from "@/typesc";
+
+export default async function fetchMovie(): Promise<MovieData[]> {
+  const url = process.env.NEXT_MOVIE_API_URL as string;
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error("영화를 불러오는데 실패했습니다.");
+    }
+
+    const data = await response.json();
+
+    return data;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+}

--- a/src/utils/fetch-one-movie.ts
+++ b/src/utils/fetch-one-movie.ts
@@ -1,0 +1,21 @@
+import { MovieData } from "@/typesc";
+
+export default async function fetchOneMovie(
+  movieId: number
+): Promise<MovieData | null> {
+  const url = process.env.NEXT_MOVIE_API_URL;
+
+  try {
+    const response = await fetch(`${url}/${movieId}`);
+    if (!response.ok) {
+      throw new Error("영화를 불러오는데 실패했습니다.");
+    }
+
+    const data = await response.json();
+
+    return data;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+}

--- a/src/utils/fetch-recommend-movie.ts
+++ b/src/utils/fetch-recommend-movie.ts
@@ -1,0 +1,19 @@
+import { MovieData } from "@/typesc";
+
+export default async function fetchRecommendMovies(): Promise<MovieData[]> {
+  const url = process.env.NEXT_MOVIE_API_URL;
+
+  try {
+    const response = await fetch(`${url}/random`);
+    if (!response.ok) {
+      throw new Error("영화를 불러오는데 실패했습니다.");
+    }
+
+    const data = await response.json();
+
+    return data;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+}


### PR DESCRIPTION
close #7 

# Ref
[미션](https://github.com/winterlood/onebite-next-challenge/tree/main/missions/day06/mission)

# 요구 사항
- [x] 1. 인덱스 페이지 데이터 페칭 구현하기 (SSR)
- [x] 2. 서치 페이지 데이터 페칭 구현하기 (SSR)
- [x] 3. 영화 상세 페이지 데이터 페칭 구현하기 (SSR)

# 에러 사항
![스크린샷 2024-09-14 오후 12 45 29](https://github.com/user-attachments/assets/25ca566c-a35f-449a-a829-581af3a2c225)
서치바에서 검색 -> 홈 이동 -> 서치바에서 검색 시 가끔 위와 같이 `Loading initial props cancelled` 에러가 뜬다.

### 인터넷 및 AI 검색 결과 에러 원인
-  빠른 페이지 전환으로 이전 통신이 취소되어 에러 발생
- router.push가 빠르게 여러번 일어난 경우
- `getServerSideProps`에서 fetch중 페이지 전환이나 리렌더링이 일어나 진행 중인 통신이 취소되어 에러 발생

종합해보면 `통신 중 새로운 이벤트(패칭, 페이지 전환, 리랜더링 등)가 발생해 이전 통신을 막아서 나오는 에러` 같다.
해결 방법으로는 `Debounce나 setTimeout 등 비동기 통신`, `캐싱 사용` 등을 알려주지만 아직 배우는 입장이니 매커니즘을 더 학습한 후에 해결 할 수 있을 것 같다. (~~일단 동작은 하니...ㅋㅋ~~)