### PR TITLE
[#11] Day07 - SSG

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-NEXT_MOVIE_API_URL = "http://localhost:12345/movie"
+NEXT_PUBLIC_MOVIE_API_URL = "http://localhost:12345/movie"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { InferGetServerSidePropsType } from "next";
+import { InferGetStaticPropsType } from "next";
 import Link from "next/link";
 
 import fetchMovie from "@/utils/fetch-movie";
@@ -10,7 +10,7 @@ import MovieItem from "@/components/movie-item";
 
 import style from "./index.module.css";
 
-export const getServerSideProps = async () => {
+export const getStaticProps = async () => {
   const [allMovies, recommendMovies] = await Promise.all([
     fetchMovie(),
     fetchRecommendMovies(),
@@ -26,7 +26,7 @@ export const getServerSideProps = async () => {
 export default function Home({
   allMovies,
   recommendMovies,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <div className={style.container}>
       <section>

--- a/src/pages/movie/[id].module.css
+++ b/src/pages/movie/[id].module.css
@@ -46,7 +46,8 @@
   text-indent: 10px;
 }
 
-.not_found {
+.not_found,
+.is_fall_back {
   text-align: center;
   font-size: large;
   font-weight: bold;

--- a/src/pages/movie/[id].tsx
+++ b/src/pages/movie/[id].tsx
@@ -1,13 +1,23 @@
-import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
+import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
 import { useRouter } from "next/router";
 
+import fetchMovie from "@/utils/fetch-movie";
 import fetchOneMovie from "@/utils/fetch-one-movie";
 
 import style from "./[id].module.css";
 
-export const getServerSideProps = async (
-  content: GetServerSidePropsContext
-) => {
+export const getStaticPaths = async () => {
+  const movies = await fetchMovie();
+
+  return {
+    paths: movies.map((movie) => ({
+      params: { id: String(movie.id) },
+    })),
+    fallback: true,
+  };
+};
+
+export const getStaticProps = async (content: GetStaticPropsContext) => {
   const movieId = Number(content.params!.id);
 
   const oneMovie = await fetchOneMovie(movieId);
@@ -21,9 +31,18 @@ export const getServerSideProps = async (
 
 export default function Page({
   oneMovie,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const router = useRouter();
-  const movieId = Number(router.query.id);
+  const movieId = router.query.id;
+  const isFallback = router.isFallback;
+
+  if (isFallback) {
+    return (
+      <div className={style.is_fall_back}>
+        <p>로딩중입니다.</p>
+      </div>
+    );
+  }
 
   if (!oneMovie) {
     return (

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,5 +1,4 @@
-import { ReactNode } from "react";
-import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
+import { ReactNode, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
 
@@ -9,37 +8,37 @@ import SearchableLayout from "@/components/searchable-layout";
 import MovieItem from "@/components/movie-item";
 
 import style from "./index.module.css";
+import { MovieData } from "@/typesc";
 
-export const getServerSideProps = async (
-  content: GetServerSidePropsContext
-) => {
-  const q = content.query.q;
+export default function Page() {
+  const [searchMovieDate, setSearchMovieDate] = useState<MovieData[]>([]);
 
-  const searchMovies = await fetchMovie(q as string);
-
-  return {
-    props: {
-      searchMovies,
-    },
-  };
-};
-
-export default function Page({
-  searchMovies,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
-  const serachName = router.query.q as string;
+  const q = router.query.q;
 
-  if (searchMovies.length === 0) {
+  const getQueryMovieDate = async () => {
+    const searchMovies = await fetchMovie(q as string);
+
+    setSearchMovieDate(searchMovies);
+  };
+
+  useEffect(() => {
+    if (q) {
+      getQueryMovieDate();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [q]);
+
+  if (searchMovieDate.length === 0) {
     return (
       <div className={style.not_found}>
-        &quot;{serachName}&quot;에 대한 검색 결과가 없습니다.
+        &quot;{q}&quot;에 대한 검색 결과가 없습니다.
       </div>
     );
   }
   return (
     <div className={style.movie_items}>
-      {searchMovies.map((movie) => {
+      {searchMovieDate.map((movie) => {
         return (
           <Link
             href={`/movie/${movie.id}`}

--- a/src/utils/fetch-movie.ts
+++ b/src/utils/fetch-movie.ts
@@ -1,10 +1,11 @@
 import { MovieData } from "@/typesc";
 
 export default async function fetchMovie(q?: string): Promise<MovieData[]> {
-  const url = process.env.NEXT_MOVIE_API_URL as string;
+  const url = process.env.NEXT_PUBLIC_MOVIE_API_URL as string;
 
   try {
-    const response = await fetch(q ? `${url}/search?q=${q}` : url);
+    const response = await fetch(q ? `${url}/search?q=${String(q)}` : url);
+
     if (!response.ok) {
       throw new Error("영화를 불러오는데 실패했습니다.");
     }

--- a/src/utils/fetch-one-movie.ts
+++ b/src/utils/fetch-one-movie.ts
@@ -3,7 +3,7 @@ import { MovieData } from "@/typesc";
 export default async function fetchOneMovie(
   movieId: number
 ): Promise<MovieData | null> {
-  const url = process.env.NEXT_MOVIE_API_URL;
+  const url = process.env.NEXT_PUBLIC_MOVIE_API_URL;
 
   try {
     const response = await fetch(`${url}/${movieId}`);

--- a/src/utils/fetch-recommend-movie.ts
+++ b/src/utils/fetch-recommend-movie.ts
@@ -1,7 +1,7 @@
 import { MovieData } from "@/typesc";
 
 export default async function fetchRecommendMovies(): Promise<MovieData[]> {
-  const url = process.env.NEXT_MOVIE_API_URL;
+  const url = process.env.NEXT_PUBLIC_MOVIE_API_URL;
 
   try {
     const response = await fetch(`${url}/random`);


### PR DESCRIPTION
close #11 

# Ref
[미션](https://github.com/winterlood/onebite-next-challenge/tree/main/missions/day07/mission)

# SSG 적용 페이지 및 근거와 이점, 고려할 점
|적용 페이지| 근거와 이점| 고려할 점|
|--|--|--|
| page/index | 실시간으로 변동될 데이터가 없고 데이터 요청이 없어진다. | 현재는 서버의 책들이 고정되어 있지만 책이 추가되면 다시 빌드해줘야 한다. |
| page/search | 쿼리스트링을 미리 정의할 수 없지만 레이아웃 자체를 미리 렌더링하고, 데이터는 추후에 업데이트하는 방법으로 하면된다. | .env 변수를  PUBLIC으로 설정해줘야 한다. |
| page/movie | SSG를 가장 잘 활용할 수 있는 페이지인거 같다. fallback을 잘 활용하여 추가된 데이터도 SSG로 관리할 수 있어서 진짜 좋은 거 같다. | 프로젝트의 특성에 맞게 fallback관리 잘하기 |


# 트러블 슈팅
`search`를 SSG로 수정 후 데이터 요청 시 서버 응답이 404가 나왔다.
개발자 도구를 보니 undefined가 들어간 엉뚱한 곳에 요청을 하고 있었다. 

<img width="589" alt="스크린샷 2024-09-19 오후 4 41 47" src="https://github.com/user-attachments/assets/bbd2cdbb-68b0-4f83-a11e-bd256305af95">

나의 친구 ChatGPT에게 물어보니 Next.js는 두 종류의 환경 변수를 지원한다고 한다.
|종류|설명|예|
|--|--|--|
|`Public` 환경 변수|클라이언트와 서버에서 모두 사용 가능한 변수|NEXT_PUBLIC_XXX|
|`Private` 환경 변수|서버 사이드에서만 사용 가능한 변수|  NEXT_XXX|

나는 후자인 `Private`한 변수를 사용하고 있었다.
```env
# .env

NEXT_MOVIE_API_URL = "http://localhost:12345/movie"
```

기존 SSR 방식에서의 `search`는 서버에서 데이터 패칭을 하여 `Private` 환경 변수를 사용해도 문제가 없었다. 하지만 SSG로 바꾸고 레이아웃만 서버에서 보내주지만 데이터 패칭을 클라이언트 딴에서 하기 때문에 내가 설정한 환경 변수를 읽지 못하는 것이었다. 그래서 `PUBLIC`을 붙여주어 잘 동작하게 하였다.

추가적으로 `Private`로 설정해도 `getStaticProps`내부에서 사용하면 사용된다고 한다. (테스트는 안해봄)





